### PR TITLE
media-mgmt-svc-soz: cargo build optimization (lld → mold)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,11 +1,11 @@
-# Use lld linker for faster linking (switch to mold if available)
+# Use mold linker for 2-10x faster linking
 [target.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [target.aarch64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["-C", "link-arg=-fuse-ld=lld"]
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
 [build]
 jobs = 4 # Limit parallel rustc processes to save RAM

--- a/.env.local.example
+++ b/.env.local.example
@@ -32,3 +32,6 @@ RUST_LOG=debug
 
 # OpenTelemetry (empty = disabled)
 OTEL_EXPORTER_OTLP_ENDPOINT=
+
+# Build (optional: relocate target/ to avoid backing up 5-10GB of build artifacts)
+# CARGO_TARGET_DIR=/tmp/cargo-target/media-management-service


### PR DESCRIPTION
## Summary
- Switch `.cargo/config.toml` linker from lld to mold for 2-10x faster linking
- Document `CARGO_TARGET_DIR` in `.env.local.example` for backup-friendly builds

## Task
Closes beads task `media-mgmt-svc-soz`: Phase 8c: Cargo build optimization

## Changes
- `.cargo/config.toml` — switch `lld` → `mold`, update comment
- `.env.local.example` — add commented-out `CARGO_TARGET_DIR` option

## Validation
- [x] `cargo check` passes with mold linker
- [x] All pre-push hooks pass (cargo-audit, cargo-test, cargo-build)
- [x] Cargo.toml profiles match design doc (already from scaffold)
- [x] `.gitignore` excludes `/target` (already from scaffold)

Generated with [Claude Code](https://claude.com/claude-code)