### PR TITLE
media-mgmt-svc-hdz: add 3-mode auth system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -1218,6 +1219,7 @@ version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
 dependencies = [
+ "aws-lc-rs",
  "base64",
  "getrandom 0.2.17",
  "js-sys",
@@ -2042,6 +2044,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -2064,7 +2067,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -2219,7 +2222,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3165,6 +3168,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ hex = "0.4"
 base64 = "0.22"
 hmac = "0.12"
 rand = "0.9"
-jsonwebtoken = "10"
-reqwest = { version = "0.13", features = ["json"] }
+jsonwebtoken = { version = "10", features = ["aws_lc_rs"] }
+reqwest = { version = "0.13", features = ["json", "form"] }
 dotenvy = "0.15"
 bytes = "1"
 futures-util = "0.3"

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,535 @@
+use axum::extract::FromRequestParts;
+use axum::extract::{Request, State};
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, request::Parts};
+use axum::middleware::Next;
+use axum::response::Response;
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use reqwest::Client;
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::config::AuthModeConfig;
+use crate::error::AppError;
+use crate::state::AppState;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub enum AuthMode {
+    OAuth2 {
+        client: Client,
+        base_url: String,
+        client_id: String,
+        client_secret: String,
+    },
+    Jwt {
+        decoding_key: DecodingKey,
+    },
+    Dev,
+}
+
+#[derive(Clone, Debug)]
+pub struct AuthUser {
+    pub user_id: Uuid,
+    pub scopes: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Claims {
+    sub: String,
+    #[serde(default)]
+    scope: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct IntrospectionResponse {
+    active: bool,
+    sub: Option<String>,
+    scope: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// AuthMode construction
+// ---------------------------------------------------------------------------
+
+impl AuthMode {
+    pub fn from_config(config: &AuthModeConfig) -> Self {
+        match config {
+            AuthModeConfig::OAuth2 {
+                base_url,
+                client_id,
+                client_secret,
+            } => Self::OAuth2 {
+                client: Client::new(),
+                base_url: base_url.clone(),
+                client_id: client_id.clone(),
+                client_secret: client_secret.clone(),
+            },
+            AuthModeConfig::Jwt { secret } => Self::Jwt {
+                decoding_key: DecodingKey::from_secret(secret.as_bytes()),
+            },
+            AuthModeConfig::Dev => Self::Dev,
+        }
+    }
+
+    pub fn name(&self) -> &'static str {
+        match self {
+            Self::OAuth2 { .. } => "oauth2",
+            Self::Jwt { .. } => "jwt",
+            Self::Dev => "dev",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Middleware
+// ---------------------------------------------------------------------------
+
+pub async fn auth_middleware(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Result<Response, AppError> {
+    let auth_user = authenticate(&state.auth_mode, request.headers()).await?;
+    request.extensions_mut().insert(auth_user);
+    Ok(next.run(request).await)
+}
+
+// ---------------------------------------------------------------------------
+// Core authentication (also callable from handlers for dual-auth)
+// ---------------------------------------------------------------------------
+
+pub async fn authenticate(auth_mode: &AuthMode, headers: &HeaderMap) -> Result<AuthUser, AppError> {
+    match auth_mode {
+        AuthMode::Dev => authenticate_dev(headers),
+        AuthMode::Jwt { decoding_key } => authenticate_jwt(headers, decoding_key),
+        AuthMode::OAuth2 {
+            client,
+            base_url,
+            client_id,
+            client_secret,
+        } => authenticate_oauth2(headers, client, base_url, client_id, client_secret).await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth strategies
+// ---------------------------------------------------------------------------
+
+fn extract_bearer_token(headers: &HeaderMap) -> Result<&str, AppError> {
+    let header = headers
+        .get(AUTHORIZATION)
+        .ok_or_else(|| AppError::Unauthorized("missing authorization header".into()))?
+        .to_str()
+        .map_err(|_| AppError::Unauthorized("invalid authorization header".into()))?;
+
+    header
+        .strip_prefix("Bearer ")
+        .ok_or_else(|| AppError::Unauthorized("invalid bearer token format".into()))
+}
+
+fn authenticate_dev(headers: &HeaderMap) -> Result<AuthUser, AppError> {
+    let value = headers
+        .get("x-user-id")
+        .ok_or_else(|| AppError::Unauthorized("missing x-user-id header".into()))?
+        .to_str()
+        .map_err(|_| AppError::Unauthorized("invalid x-user-id header".into()))?;
+
+    let user_id = Uuid::parse_str(value)
+        .map_err(|_| AppError::Unauthorized("x-user-id is not a valid UUID".into()))?;
+
+    Ok(AuthUser {
+        user_id,
+        scopes: vec!["media:read".into(), "media:write".into()],
+    })
+}
+
+fn authenticate_jwt(headers: &HeaderMap, decoding_key: &DecodingKey) -> Result<AuthUser, AppError> {
+    let token = extract_bearer_token(headers)?;
+
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_issuer(&["auth-service"]);
+    validation.set_required_spec_claims(&["sub", "exp", "iss"]);
+
+    let token_data = decode::<Claims>(token, decoding_key, &validation)
+        .map_err(|e| AppError::Unauthorized(format!("invalid token: {e}")))?;
+
+    let user_id = Uuid::parse_str(&token_data.claims.sub)
+        .map_err(|_| AppError::Unauthorized("sub claim is not a valid UUID".into()))?;
+
+    let scopes = token_data
+        .claims
+        .scope
+        .map(|s| s.split_whitespace().map(String::from).collect())
+        .unwrap_or_default();
+
+    Ok(AuthUser { user_id, scopes })
+}
+
+async fn authenticate_oauth2(
+    headers: &HeaderMap,
+    client: &Client,
+    base_url: &str,
+    client_id: &str,
+    client_secret: &str,
+) -> Result<AuthUser, AppError> {
+    let token = extract_bearer_token(headers)?;
+
+    let response = client
+        .post(format!("{base_url}/oauth2/introspect"))
+        .basic_auth(client_id, Some(client_secret))
+        .form(&[("token", token)])
+        .send()
+        .await
+        .map_err(|e| AppError::ServiceUnavailable(format!("auth service request failed: {e}")))?;
+
+    if !response.status().is_success() {
+        return Err(AppError::ServiceUnavailable(
+            "auth service returned an error".into(),
+        ));
+    }
+
+    let body: IntrospectionResponse = response
+        .json()
+        .await
+        .map_err(|e| AppError::Internal(format!("auth service response parse error: {e}")))?;
+
+    if !body.active {
+        return Err(AppError::Unauthorized("token is not active".into()));
+    }
+
+    let sub = body
+        .sub
+        .ok_or_else(|| AppError::Unauthorized("missing sub in introspection response".into()))?;
+
+    let user_id = Uuid::parse_str(&sub)
+        .map_err(|_| AppError::Unauthorized("sub is not a valid UUID".into()))?;
+
+    let scopes: Vec<String> = body
+        .scope
+        .map(|s| s.split_whitespace().map(String::from).collect())
+        .unwrap_or_default();
+
+    Ok(AuthUser { user_id, scopes })
+}
+
+// ---------------------------------------------------------------------------
+// Extractor
+// ---------------------------------------------------------------------------
+
+impl<S> FromRequestParts<S> for AuthUser
+where
+    S: Send + Sync,
+{
+    type Rejection = AppError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<Self>()
+            .cloned()
+            .ok_or_else(|| AppError::Unauthorized("not authenticated".into()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+    use jsonwebtoken::{EncodingKey, Header};
+    use serde::Serialize;
+
+    const TEST_SECRET: &str = "test-secret-key-for-unit-tests";
+
+    fn dev_mode() -> AuthMode {
+        AuthMode::Dev
+    }
+
+    fn jwt_mode() -> AuthMode {
+        AuthMode::Jwt {
+            decoding_key: DecodingKey::from_secret(TEST_SECRET.as_bytes()),
+        }
+    }
+
+    #[derive(Debug, Serialize)]
+    struct TestClaims {
+        sub: String,
+        iss: String,
+        exp: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        scope: Option<String>,
+    }
+
+    fn make_jwt(claims: &TestClaims) -> String {
+        let key = EncodingKey::from_secret(TEST_SECRET.as_bytes());
+        jsonwebtoken::encode(&Header::new(Algorithm::HS256), claims, &key).unwrap()
+    }
+
+    fn future_exp() -> u64 {
+        (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs())
+            + 3600
+    }
+
+    fn past_exp() -> u64 {
+        (std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs())
+        .saturating_sub(3600)
+    }
+
+    // -- Dev mode tests --
+
+    #[tokio::test]
+    async fn dev_mode_valid_uuid() {
+        let mut headers = HeaderMap::new();
+        let uid = Uuid::new_v4();
+        headers.insert(
+            "x-user-id",
+            HeaderValue::from_str(&uid.to_string()).unwrap(),
+        );
+
+        let result = authenticate(&dev_mode(), &headers).await;
+        let user = result.unwrap();
+        assert_eq!(user.user_id, uid);
+        assert_eq!(user.scopes, vec!["media:read", "media:write"]);
+    }
+
+    #[tokio::test]
+    async fn dev_mode_missing_header() {
+        let headers = HeaderMap::new();
+        let result = authenticate(&dev_mode(), &headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn dev_mode_invalid_uuid() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-user-id", HeaderValue::from_static("not-a-uuid"));
+
+        let result = authenticate(&dev_mode(), &headers).await;
+        assert!(result.is_err());
+    }
+
+    // -- JWT mode tests --
+
+    #[tokio::test]
+    async fn jwt_mode_valid_token() {
+        let uid = Uuid::new_v4();
+        let claims = TestClaims {
+            sub: uid.to_string(),
+            iss: "auth-service".into(),
+            exp: future_exp(),
+            scope: Some("media:read media:write".into()),
+        };
+        let token = make_jwt(&claims);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+
+        let result = authenticate(&jwt_mode(), &headers).await;
+        let user = result.unwrap();
+        assert_eq!(user.user_id, uid);
+        assert_eq!(user.scopes, vec!["media:read", "media:write"]);
+    }
+
+    #[tokio::test]
+    async fn jwt_mode_expired_token() {
+        let claims = TestClaims {
+            sub: Uuid::new_v4().to_string(),
+            iss: "auth-service".into(),
+            exp: past_exp(),
+            scope: None,
+        };
+        let token = make_jwt(&claims);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+
+        let result = authenticate(&jwt_mode(), &headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn jwt_mode_wrong_issuer() {
+        let claims = TestClaims {
+            sub: Uuid::new_v4().to_string(),
+            iss: "wrong-issuer".into(),
+            exp: future_exp(),
+            scope: None,
+        };
+        let token = make_jwt(&claims);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+
+        let result = authenticate(&jwt_mode(), &headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn jwt_mode_missing_bearer() {
+        let headers = HeaderMap::new();
+        let result = authenticate(&jwt_mode(), &headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn jwt_mode_no_scope_claim() {
+        let uid = Uuid::new_v4();
+        let claims = TestClaims {
+            sub: uid.to_string(),
+            iss: "auth-service".into(),
+            exp: future_exp(),
+            scope: None,
+        };
+        let token = make_jwt(&claims);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+        );
+
+        let result = authenticate(&jwt_mode(), &headers).await;
+        let user = result.unwrap();
+        assert_eq!(user.user_id, uid);
+        assert!(user.scopes.is_empty());
+    }
+
+    // -- Bearer extraction tests --
+
+    #[test]
+    fn bearer_extraction_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer my-token-123"),
+        );
+        let token = extract_bearer_token(&headers).unwrap();
+        assert_eq!(token, "my-token-123");
+    }
+
+    #[test]
+    fn bearer_extraction_missing() {
+        let headers = HeaderMap::new();
+        assert!(extract_bearer_token(&headers).is_err());
+    }
+
+    #[test]
+    fn bearer_extraction_wrong_scheme() {
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Basic abc123"));
+        assert!(extract_bearer_token(&headers).is_err());
+    }
+
+    // -- OAuth2 mode tests --
+
+    #[tokio::test]
+    async fn oauth2_mode_active_token() {
+        let server = wiremock::MockServer::start().await;
+        let uid = Uuid::new_v4();
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/oauth2/introspect"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "active": true,
+                    "sub": uid.to_string(),
+                    "scope": "media:read media:write",
+                })),
+            )
+            .mount(&server)
+            .await;
+
+        let mode = AuthMode::OAuth2 {
+            client: Client::new(),
+            base_url: server.uri(),
+            client_id: "test-client".into(),
+            client_secret: "test-secret".into(),
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer some-opaque-token"),
+        );
+
+        let user = authenticate(&mode, &headers).await.unwrap();
+        assert_eq!(user.user_id, uid);
+        assert_eq!(user.scopes, vec!["media:read", "media:write"]);
+    }
+
+    #[tokio::test]
+    async fn oauth2_mode_inactive_token() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/oauth2/introspect"))
+            .respond_with(
+                wiremock::ResponseTemplate::new(200)
+                    .set_body_json(serde_json::json!({ "active": false })),
+            )
+            .mount(&server)
+            .await;
+
+        let mode = AuthMode::OAuth2 {
+            client: Client::new(),
+            base_url: server.uri(),
+            client_id: "test-client".into(),
+            client_secret: "test-secret".into(),
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_static("Bearer expired-token"),
+        );
+
+        let result = authenticate(&mode, &headers).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn oauth2_mode_service_error() {
+        let server = wiremock::MockServer::start().await;
+
+        wiremock::Mock::given(wiremock::matchers::method("POST"))
+            .and(wiremock::matchers::path("/oauth2/introspect"))
+            .respond_with(wiremock::ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let mode = AuthMode::OAuth2 {
+            client: Client::new(),
+            base_url: server.uri(),
+            client_id: "test-client".into(),
+            client_secret: "test-secret".into(),
+        };
+
+        let mut headers = HeaderMap::new();
+        headers.insert(AUTHORIZATION, HeaderValue::from_static("Bearer some-token"));
+
+        let result = authenticate(&mode, &headers).await;
+        assert!(result.is_err());
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,5 @@
 use axum::Json;
-use axum::body::{Body, Bytes};
+use axum::body::Body;
 use axum::extract::{Multipart, Path, Query, State};
 use axum::http::header;
 use axum::http::{HeaderMap, StatusCode};
@@ -7,8 +7,10 @@ use axum::response::{IntoResponse, Response};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tokio_util::io::ReaderStream;
+
 use uuid::Uuid;
 
+use crate::auth::{self, AuthUser};
 use crate::db;
 use crate::error::AppError;
 use crate::models::{
@@ -21,18 +23,6 @@ use crate::state::AppState;
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Temporary user-ID extraction from the `x-user-id` header.
-/// Replaced by auth middleware in Phase 5.
-fn extract_user_id(headers: &HeaderMap) -> Result<Uuid, AppError> {
-    let value = headers
-        .get("x-user-id")
-        .ok_or_else(|| AppError::Unauthorized("missing x-user-id header".into()))?
-        .to_str()
-        .map_err(|_| AppError::BadRequest("x-user-id header is not valid UTF-8".into()))?;
-
-    Uuid::parse_str(value).map_err(|_| AppError::BadRequest("x-user-id is not a valid UUID".into()))
-}
 
 fn media_to_dto(media: &Media, signing_secret: &str, ttl_secs: u64) -> MediaDto {
     let download_url = presigned::generate_download_url(
@@ -76,15 +66,15 @@ pub struct UploadQuery {
 }
 
 // ---------------------------------------------------------------------------
-// Handlers
+// Handlers (behind auth middleware)
 // ---------------------------------------------------------------------------
 
 pub async fn upload_media(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    auth_user: AuthUser,
     mut multipart: Multipart,
 ) -> Result<impl IntoResponse, AppError> {
-    let user_id = extract_user_id(&headers)?;
+    let user_id = auth_user.user_id;
 
     let field = multipart
         .next_field()
@@ -152,11 +142,9 @@ pub async fn upload_media(
 
 pub async fn get_media(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    _auth_user: AuthUser,
     Path(media_id): Path<i64>,
 ) -> Result<Json<MediaDto>, AppError> {
-    let _user_id = extract_user_id(&headers)?;
-
     let media = db::find_media_by_id(&state.db_pool, media_id)
         .await?
         .ok_or(AppError::NotFound("media"))?;
@@ -171,10 +159,10 @@ pub async fn get_media(
 
 pub async fn list_media(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    auth_user: AuthUser,
     Query(query): Query<ListMediaQuery>,
 ) -> Result<Json<PaginatedMediaResponse>, AppError> {
-    let user_id = extract_user_id(&headers)?;
+    let user_id = auth_user.user_id;
 
     let scope_user_id = query
         .uploaded_by
@@ -223,11 +211,9 @@ pub async fn list_media(
 
 pub async fn delete_media(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    _auth_user: AuthUser,
     Path(media_id): Path<i64>,
 ) -> Result<StatusCode, AppError> {
-    let _user_id = extract_user_id(&headers)?;
-
     let media = db::find_media_by_id(&state.db_pool, media_id)
         .await?
         .ok_or(AppError::NotFound("media"))?;
@@ -249,7 +235,8 @@ pub async fn download_media(
     Path(media_id): Path<i64>,
     Query(query): Query<DownloadQuery>,
 ) -> Result<Response, AppError> {
-    let is_authed = extract_user_id(&headers).is_ok();
+    // Dual auth: try bearer token first, fall back to signed URL.
+    let is_authed = auth::authenticate(&state.auth_mode, &headers).await.is_ok();
 
     if !is_authed {
         let signature = query.signature.as_deref().ok_or_else(|| {
@@ -289,11 +276,9 @@ pub async fn download_media(
 
 pub async fn get_upload_status(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    _auth_user: AuthUser,
     Path(media_id): Path<i64>,
 ) -> Result<Json<UploadStatusResponse>, AppError> {
-    let _user_id = extract_user_id(&headers)?;
-
     let media = db::find_media_by_id(&state.db_pool, media_id)
         .await?
         .ok_or(AppError::NotFound("media"))?;
@@ -329,10 +314,10 @@ pub async fn get_upload_status(
 
 pub async fn initiate_upload(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    auth_user: AuthUser,
     Json(req): Json<InitiateUploadRequest>,
 ) -> Result<impl IntoResponse, AppError> {
-    let user_id = extract_user_id(&headers)?;
+    let user_id = auth_user.user_id;
 
     if req.filename.trim().is_empty() {
         return Err(AppError::BadRequest("filename must not be empty".into()));
@@ -392,7 +377,7 @@ pub async fn upload_file(
     State(state): State<AppState>,
     Path(token): Path<String>,
     Query(query): Query<UploadQuery>,
-    body: Bytes,
+    body: axum::body::Bytes,
 ) -> Result<impl IntoResponse, AppError> {
     // URL-decode the content_type (e.g. "image%2Fjpeg" -> "image/jpeg")
     let content_type = query.content_type.replace("%2F", "/");
@@ -467,25 +452,23 @@ pub async fn upload_file(
 }
 
 // ---------------------------------------------------------------------------
-// Association handlers
+// Association handlers (behind auth middleware)
 // ---------------------------------------------------------------------------
 
 pub async fn get_media_by_recipe(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    _auth_user: AuthUser,
     Path(recipe_id): Path<i64>,
 ) -> Result<Json<MediaIdsResponse>, AppError> {
-    let _user_id = extract_user_id(&headers)?;
     let ids = db::find_media_ids_by_recipe(&state.db_pool, recipe_id).await?;
     Ok(Json(MediaIdsResponse { media_ids: ids }))
 }
 
 pub async fn get_media_by_ingredient(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    _auth_user: AuthUser,
     Path((recipe_id, ingredient_id)): Path<(i64, i64)>,
 ) -> Result<Json<MediaIdsResponse>, AppError> {
-    let _user_id = extract_user_id(&headers)?;
     let ids =
         db::find_media_ids_by_recipe_ingredient(&state.db_pool, recipe_id, ingredient_id).await?;
     Ok(Json(MediaIdsResponse { media_ids: ids }))
@@ -493,10 +476,9 @@ pub async fn get_media_by_ingredient(
 
 pub async fn get_media_by_step(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    _auth_user: AuthUser,
     Path((recipe_id, step_id)): Path<(i64, i64)>,
 ) -> Result<Json<MediaIdsResponse>, AppError> {
-    let _user_id = extract_user_id(&headers)?;
     let ids = db::find_media_ids_by_recipe_step(&state.db_pool, recipe_id, step_id).await?;
     Ok(Json(MediaIdsResponse { media_ids: ids }))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 #![allow(clippy::module_name_repetitions)]
 #![allow(clippy::missing_panics_doc)]
 
+pub mod auth;
 pub mod config;
 pub mod db;
 pub mod error;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use media_management_service::auth::AuthMode;
 use media_management_service::config::{Config, RunMode};
 use media_management_service::db;
 use media_management_service::routes;
@@ -37,10 +38,14 @@ async fn main() {
         .expect("failed to initialise storage");
     tracing::info!("storage initialised");
 
+    let auth_mode = AuthMode::from_config(&config.auth);
+    tracing::info!("auth mode: {}", auth_mode.name());
+
     let state = AppState {
         db_pool,
         storage,
         config: config.clone(),
+        auth_mode,
     };
     let app = routes::router(state);
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,12 +1,14 @@
 use axum::Router;
+use axum::middleware;
 use axum::routing::{get, post, put};
 
+use crate::auth;
 use crate::handlers;
 use crate::health;
 use crate::state::AppState;
 
 pub fn router(state: AppState) -> Router {
-    // Media CRUD routes: Phase 5 will wrap these with auth middleware.
+    // Media CRUD routes: protected by auth middleware.
     let media_routes = Router::new()
         .route(
             "/media",
@@ -26,7 +28,11 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/media/recipe/{rid}/step/{id}",
             get(handlers::get_media_by_step),
-        );
+        )
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth::auth_middleware,
+        ));
 
     // Download endpoint handles its own dual auth (bearer or signed URL).
     let download_route = Router::new().route("/media/{id}/download", get(handlers::download_media));

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,6 @@
 use sqlx::PgPool;
 
+use crate::auth::AuthMode;
 use crate::config::Config;
 use crate::storage::Storage;
 
@@ -8,4 +9,5 @@ pub struct AppState {
     pub db_pool: PgPool,
     pub storage: Storage,
     pub config: Config,
+    pub auth_mode: AuthMode,
 }


### PR DESCRIPTION
## Summary
- Implement `src/auth.rs` with `AuthMode` enum (OAuth2/JWT/Dev), `AuthUser` struct, and Axum middleware
- Wire auth middleware onto all `/media/` CRUD routes; download and upload routes retain their own auth
- Migrate all handlers from temporary `extract_user_id` shim to `AuthUser` extractor
- Add `aws_lc_rs` crypto provider for `jsonwebtoken` and `form` feature for `reqwest`

## Task
Closes beads task `media-mgmt-svc-hdz`: Phase 5: Auth system (3-mode)

## Changes
- `src/auth.rs` (new) — AuthMode enum, AuthUser struct, auth_middleware, authenticate fn, 14 unit tests
- `src/lib.rs` — add `pub mod auth`
- `src/state.rs` — add `auth_mode: AuthMode` field to AppState
- `src/main.rs` — build AuthMode from config, pass to AppState
- `src/routes.rs` — wrap media_routes with auth middleware layer
- `src/handlers.rs` — remove extract_user_id shim, use AuthUser extractor, update download_media dual auth
- `Cargo.toml` — add jsonwebtoken aws_lc_rs feature, reqwest form feature

## Validation
- [x] All 87 tests pass (14 new auth tests)
- [x] Lint clean (clippy pedantic, cargo-deny)
- [x] Format clean (rustfmt, taplo)
- [x] All pre-commit and pre-push hooks pass

Generated with [Claude Code](https://claude.com/claude-code)