### PR TITLE
media-mgmt-svc-5xw: add production middleware stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -598,12 +612,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -774,6 +804,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "governor"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand 0.9.2",
+ "smallvec",
+ "spinning_top",
+ "web-time",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,13 +847,19 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -808,6 +867,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1369,6 +1433,7 @@ dependencies = [
  "tokio-util",
  "tower",
  "tower-http",
+ "tower_governor",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -1425,6 +1490,18 @@ dependencies = [
  "spin",
  "version_check",
 ]
+
+[[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1719,6 +1796,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1791,6 +1874,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1927,6 +2025,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2461,6 +2568,15 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -3032,6 +3148,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.18",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3429,6 +3561,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3436,6 +3584,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ tower-http = { version = "0.6", features = [
   "request-id",
 ] }
 tower = "0.5"
+tower_governor = { version = "0.8", default-features = false, features = [
+  "axum",
+] }
 sqlx = { version = "0.8", features = [
   "postgres",
   "runtime-tokio-rustls",
@@ -48,6 +51,7 @@ opentelemetry-otlp = "0.28"
 tracing-opentelemetry = "0.29"
 
 [dev-dependencies]
+tower = { version = "0.5", features = ["util"] }
 tempfile = "3"
 rstest = "0.24"
 wiremock = "0.6"

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct Config {
     pub auth: AuthModeConfig,
     pub run_mode: RunMode,
     pub otel_endpoint: Option<String>,
+    pub cors_allowed_origins: Vec<String>,
 }
 
 impl Config {
@@ -101,6 +102,14 @@ impl Config {
             .ok()
             .filter(|s| !s.is_empty());
 
+        let cors_allowed_origins: Vec<String> = env::var("CORS_ALLOWED_ORIGINS")
+            .unwrap_or_default()
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+
         Self {
             host,
             port,
@@ -115,6 +124,7 @@ impl Config {
             auth,
             run_mode,
             otel_endpoint,
+            cors_allowed_origins,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod db;
 pub mod error;
 pub mod handlers;
 pub mod health;
+pub mod middleware;
 pub mod models;
 pub mod presigned;
 pub mod routes;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,0 +1,242 @@
+use std::time::Duration;
+
+use axum::http::header::{self, HeaderName};
+use axum::http::{HeaderValue, Request, StatusCode};
+use tower_http::compression::CompressionLayer;
+use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
+use tower_http::request_id::{
+    MakeRequestId, PropagateRequestIdLayer, RequestId, SetRequestIdLayer,
+};
+use tower_http::set_header::SetResponseHeaderLayer;
+use tower_http::timeout::TimeoutLayer;
+use tower_http::trace::{MakeSpan, TraceLayer};
+
+use crate::config::{Config, RunMode};
+
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+pub const RATE_LIMIT_PER_SECOND: u64 = 10;
+pub const RATE_LIMIT_BURST: u32 = 50;
+
+// -- Request ID -----------------------------------------------------------
+
+#[derive(Clone, Default)]
+pub struct RequestIdGenerator;
+
+impl MakeRequestId for RequestIdGenerator {
+    fn make_request_id<B>(&mut self, _request: &Request<B>) -> Option<RequestId> {
+        let id = uuid::Uuid::new_v4().to_string();
+        id.parse().ok().map(RequestId::new)
+    }
+}
+
+pub fn request_id_layer() -> SetRequestIdLayer<RequestIdGenerator> {
+    SetRequestIdLayer::x_request_id(RequestIdGenerator)
+}
+
+pub fn propagate_request_id_layer() -> PropagateRequestIdLayer {
+    PropagateRequestIdLayer::x_request_id()
+}
+
+// -- Tracing --------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct RequestIdSpan;
+
+impl<B> MakeSpan<B> for RequestIdSpan {
+    fn make_span(&mut self, request: &Request<B>) -> tracing::Span {
+        let request_id = request
+            .headers()
+            .get("x-request-id")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("-");
+        tracing::info_span!(
+            "http_request",
+            method = %request.method(),
+            uri = %request.uri(),
+            request_id = %request_id,
+        )
+    }
+}
+
+pub fn trace_layer() -> TraceLayer<
+    tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
+    RequestIdSpan,
+> {
+    TraceLayer::new_for_http().make_span_with(RequestIdSpan)
+}
+
+// -- CORS -----------------------------------------------------------------
+
+pub fn cors_layer(config: &Config) -> CorsLayer {
+    if config.run_mode == RunMode::Local {
+        return CorsLayer::very_permissive();
+    }
+
+    if config.cors_allowed_origins.is_empty() {
+        return CorsLayer::new();
+    }
+
+    let origins: Vec<HeaderValue> = config
+        .cors_allowed_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods(AllowMethods::list([
+            axum::http::Method::GET,
+            axum::http::Method::POST,
+            axum::http::Method::PUT,
+            axum::http::Method::DELETE,
+            axum::http::Method::OPTIONS,
+        ]))
+        .allow_headers(AllowHeaders::list([
+            header::AUTHORIZATION,
+            header::CONTENT_TYPE,
+            HeaderName::from_static("x-request-id"),
+        ]))
+}
+
+// -- Compression ----------------------------------------------------------
+
+pub fn compression_layer() -> CompressionLayer {
+    CompressionLayer::new()
+}
+
+// -- Timeout --------------------------------------------------------------
+
+pub fn timeout_layer() -> TimeoutLayer {
+    TimeoutLayer::with_status_code(
+        StatusCode::REQUEST_TIMEOUT,
+        Duration::from_secs(REQUEST_TIMEOUT_SECS),
+    )
+}
+
+// -- Security headers -----------------------------------------------------
+
+pub fn nosniff_layer() -> SetResponseHeaderLayer<HeaderValue> {
+    SetResponseHeaderLayer::overriding(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    )
+}
+
+pub fn frame_deny_layer() -> SetResponseHeaderLayer<HeaderValue> {
+    SetResponseHeaderLayer::overriding(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"))
+}
+
+pub fn referrer_policy_layer() -> SetResponseHeaderLayer<HeaderValue> {
+    SetResponseHeaderLayer::overriding(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("strict-origin-when-cross-origin"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    fn test_config(run_mode: RunMode, origins: Vec<String>) -> Config {
+        Config {
+            host: "0.0.0.0".into(),
+            port: 3000,
+            max_upload_size: 1024,
+            database_url: String::new(),
+            db_max_connections: 1,
+            storage_base_path: String::new(),
+            storage_temp_path: String::new(),
+            download_url_ttl_secs: 86400,
+            upload_url_ttl_secs: 900,
+            signing_secret: "test-secret".into(),
+            auth: crate::config::AuthModeConfig::Dev,
+            run_mode,
+            otel_endpoint: None,
+            cors_allowed_origins: origins,
+        }
+    }
+
+    #[test]
+    fn request_id_generates_valid_uuid() {
+        let mut generator = RequestIdGenerator;
+        let req = Request::builder().body(()).unwrap();
+        let id = generator
+            .make_request_id(&req)
+            .expect("should generate an ID");
+        let value = id.header_value().to_str().unwrap().to_string();
+        uuid::Uuid::parse_str(&value).expect("should be a valid UUID");
+    }
+
+    #[tokio::test]
+    async fn request_id_propagated_to_response() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(propagate_request_id_layer())
+            .layer(request_id_layer());
+
+        let req = Request::builder()
+            .uri("/")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+
+        let id = resp
+            .headers()
+            .get("x-request-id")
+            .expect("x-request-id header should be present");
+        let value = id.to_str().unwrap();
+        uuid::Uuid::parse_str(value).expect("should be a valid UUID");
+    }
+
+    #[tokio::test]
+    async fn security_headers_present_on_response() {
+        let app = Router::new()
+            .route("/", get(|| async { "ok" }))
+            .layer(nosniff_layer())
+            .layer(frame_deny_layer())
+            .layer(referrer_policy_layer());
+
+        let req = Request::builder()
+            .uri("/")
+            .body(axum::body::Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+
+        assert_eq!(
+            resp.headers().get(header::X_CONTENT_TYPE_OPTIONS).unwrap(),
+            "nosniff"
+        );
+        assert_eq!(resp.headers().get(header::X_FRAME_OPTIONS).unwrap(), "DENY");
+        assert_eq!(
+            resp.headers().get("referrer-policy").unwrap(),
+            "strict-origin-when-cross-origin"
+        );
+    }
+
+    #[test]
+    fn cors_permissive_in_local_mode() {
+        let config = test_config(RunMode::Local, vec![]);
+        let _layer = cors_layer(&config);
+    }
+
+    #[test]
+    fn cors_restrictive_in_production_without_origins() {
+        let config = test_config(RunMode::Production, vec![]);
+        let _layer = cors_layer(&config);
+    }
+
+    #[test]
+    fn cors_restrictive_in_production_with_origins() {
+        let config = test_config(
+            RunMode::Production,
+            vec![
+                "https://example.com".into(),
+                "https://app.example.com".into(),
+            ],
+        );
+        let _layer = cors_layer(&config);
+    }
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,10 +1,16 @@
+use std::sync::Arc;
+
 use axum::Router;
-use axum::middleware;
+use axum::middleware as axum_mw;
 use axum::routing::{get, post, put};
+use tower_governor::GovernorLayer;
+use tower_governor::governor::GovernorConfigBuilder;
+use tower_governor::key_extractor::GlobalKeyExtractor;
 
 use crate::auth;
 use crate::handlers;
 use crate::health;
+use crate::middleware;
 use crate::state::AppState;
 
 pub fn router(state: AppState) -> Router {
@@ -29,7 +35,7 @@ pub fn router(state: AppState) -> Router {
             "/media/recipe/{rid}/step/{id}",
             get(handlers::get_media_by_step),
         )
-        .layer(middleware::from_fn_with_state(
+        .layer(axum_mw::from_fn_with_state(
             state.clone(),
             auth::auth_middleware,
         ));
@@ -44,6 +50,17 @@ pub fn router(state: AppState) -> Router {
         .route("/health", get(health::health))
         .route("/ready", get(health::ready));
 
+    let cors = middleware::cors_layer(&state.config);
+
+    let governor_config = Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(middleware::RATE_LIMIT_PER_SECOND)
+            .burst_size(middleware::RATE_LIMIT_BURST)
+            .key_extractor(GlobalKeyExtractor)
+            .finish()
+            .expect("rate limiter config is valid"),
+    );
+
     Router::new()
         .nest(
             "/api/v1/media-management",
@@ -53,4 +70,17 @@ pub fn router(state: AppState) -> Router {
                 .merge(health_routes),
         )
         .with_state(state)
+        // Layers applied in reverse: last .layer() call = outermost middleware.
+        // Outermost → Innermost: RequestId, Trace, PropagateId, CORS,
+        //   RateLimit, Timeout, Compression, SecurityHeaders
+        .layer(middleware::nosniff_layer())
+        .layer(middleware::frame_deny_layer())
+        .layer(middleware::referrer_policy_layer())
+        .layer(middleware::compression_layer())
+        .layer(middleware::timeout_layer())
+        .layer(GovernorLayer::new(governor_config))
+        .layer(cors)
+        .layer(middleware::propagate_request_id_layer())
+        .layer(middleware::trace_layer())
+        .layer(middleware::request_id_layer())
 }


### PR DESCRIPTION
## Summary
- Add 6 middleware layers to the router: request ID (UUID v4), CORS, gzip compression, 30s timeout, security headers, and global rate limiting
- New `src/middleware.rs` module with builder functions for each layer and 6 unit tests
- CORS is permissive in local mode, restrictive in production (configurable via `CORS_ALLOWED_ORIGINS` env var)
- Rate limiting uses `tower_governor` with `GlobalKeyExtractor` at 10 req/s with burst of 50

## Task
Closes beads task `media-mgmt-svc-5xw`: Phase 6: Middleware stack

## Changes
- `Cargo.toml` — added `tower_governor` dependency
- `src/middleware.rs` — **new** — all middleware builder functions, `RequestIdGenerator`, `RequestIdSpan`, constants
- `src/config.rs` — added `cors_allowed_origins: Vec<String>` field with `CORS_ALLOWED_ORIGINS` env var
- `src/lib.rs` — registered `middleware` module
- `src/routes.rs` — applied 8 middleware layers in correct ordering on the final router

## Validation
- [x] All 93 tests pass
- [x] Clippy clean (deny all + pedantic)
- [x] cargo-deny, cargo-audit, gitleaks clean
- [x] commitlint, taplo, cargo-fmt pass

Generated with [Claude Code](https://claude.com/claude-code)