### PR TITLE
media-mgmt-svc-9qa: add OpenTelemetry integration

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -69,6 +69,17 @@ pub struct UploadQuery {
 // Handlers (behind auth middleware)
 // ---------------------------------------------------------------------------
 
+#[tracing::instrument(
+    name = "upload_media",
+    skip_all,
+    fields(
+        operation = "upload_media",
+        user_id = %auth_user.user_id,
+        media_id = tracing::field::Empty,
+        original_filename = tracing::field::Empty,
+        content_hash = tracing::field::Empty,
+    )
+)]
 pub async fn upload_media(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -83,6 +94,7 @@ pub async fn upload_media(
         .ok_or_else(|| AppError::BadRequest("missing file field".into()))?;
 
     let original_filename = field.file_name().unwrap_or("unnamed").to_string();
+    tracing::Span::current().record("original_filename", &original_filename);
     let media_type = field
         .content_type()
         .unwrap_or("application/octet-stream")
@@ -102,6 +114,7 @@ pub async fn upload_media(
     let hash_bytes = Sha256::digest(&data);
     let hash_hex = hex::encode(hash_bytes);
     let content_hash = ContentHash::new(&hash_hex)?;
+    tracing::Span::current().record("content_hash", content_hash.as_str());
 
     // Dedup: return existing record if same content already stored
     if let Some(existing) =
@@ -127,6 +140,7 @@ pub async fn upload_media(
         processing_status: "complete".to_string(),
     };
     let media_id = db::save_media(&state.db_pool, &new_media).await?;
+    tracing::Span::current().record("media_id", media_id);
 
     let media = db::find_media_by_id(&state.db_pool, media_id)
         .await?
@@ -140,6 +154,7 @@ pub async fn upload_media(
     Ok((StatusCode::CREATED, Json(dto)))
 }
 
+#[tracing::instrument(name = "get_media", skip_all, fields(operation = "get_media", media_id = %media_id))]
 pub async fn get_media(
     State(state): State<AppState>,
     _auth_user: AuthUser,
@@ -157,6 +172,7 @@ pub async fn get_media(
     Ok(Json(dto))
 }
 
+#[tracing::instrument(name = "list_media", skip_all, fields(operation = "list_media", user_id = %auth_user.user_id))]
 pub async fn list_media(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -209,6 +225,7 @@ pub async fn list_media(
     Ok(Json(response))
 }
 
+#[tracing::instrument(name = "delete_media", skip_all, fields(operation = "delete_media", media_id = %media_id))]
 pub async fn delete_media(
     State(state): State<AppState>,
     _auth_user: AuthUser,
@@ -229,6 +246,7 @@ pub async fn delete_media(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[tracing::instrument(name = "download_media", skip_all, fields(operation = "download_media", media_id = %media_id))]
 pub async fn download_media(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -274,6 +292,7 @@ pub async fn download_media(
         .map_err(|e| AppError::Internal(format!("failed to build response: {e}")))
 }
 
+#[tracing::instrument(name = "get_upload_status", skip_all, fields(operation = "get_upload_status", media_id = %media_id))]
 pub async fn get_upload_status(
     State(state): State<AppState>,
     _auth_user: AuthUser,
@@ -312,6 +331,11 @@ pub async fn get_upload_status(
 // Presigned upload handlers
 // ---------------------------------------------------------------------------
 
+#[tracing::instrument(
+    name = "initiate_upload",
+    skip_all,
+    fields(operation = "initiate_upload", user_id = %auth_user.user_id, media_id = tracing::field::Empty)
+)]
 pub async fn initiate_upload(
     State(state): State<AppState>,
     auth_user: AuthUser,
@@ -349,6 +373,7 @@ pub async fn initiate_upload(
         processing_status: "pending".to_string(),
     };
     let media_id = db::save_media(&state.db_pool, &new_media).await?;
+    tracing::Span::current().record("media_id", media_id);
 
     let token = presigned::generate_upload_token(media_id);
     let (upload_url, expires) = presigned::sign_upload_url(
@@ -373,6 +398,11 @@ pub async fn initiate_upload(
     Ok((StatusCode::OK, Json(response)))
 }
 
+#[tracing::instrument(
+    name = "upload_file",
+    skip_all,
+    fields(operation = "upload_file", token = %token, media_id = tracing::field::Empty)
+)]
 pub async fn upload_file(
     State(state): State<AppState>,
     Path(token): Path<String>,
@@ -392,6 +422,7 @@ pub async fn upload_file(
     )?;
 
     let media_id = presigned::decode_upload_token(&token)?;
+    tracing::Span::current().record("media_id", media_id);
 
     let mut media = db::find_media_by_id(&state.db_pool, media_id)
         .await?
@@ -455,6 +486,7 @@ pub async fn upload_file(
 // Association handlers (behind auth middleware)
 // ---------------------------------------------------------------------------
 
+#[tracing::instrument(name = "get_media_by_recipe", skip_all, fields(operation = "get_media_by_recipe", recipe_id = %recipe_id))]
 pub async fn get_media_by_recipe(
     State(state): State<AppState>,
     _auth_user: AuthUser,
@@ -464,6 +496,7 @@ pub async fn get_media_by_recipe(
     Ok(Json(MediaIdsResponse { media_ids: ids }))
 }
 
+#[tracing::instrument(name = "get_media_by_ingredient", skip_all, fields(operation = "get_media_by_ingredient", recipe_id = %recipe_id, ingredient_id = %ingredient_id))]
 pub async fn get_media_by_ingredient(
     State(state): State<AppState>,
     _auth_user: AuthUser,
@@ -474,6 +507,7 @@ pub async fn get_media_by_ingredient(
     Ok(Json(MediaIdsResponse { media_ids: ids }))
 }
 
+#[tracing::instrument(name = "get_media_by_step", skip_all, fields(operation = "get_media_by_step", recipe_id = %recipe_id, step_id = %step_id))]
 pub async fn get_media_by_step(
     State(state): State<AppState>,
     _auth_user: AuthUser,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,4 @@ pub mod presigned;
 pub mod routes;
 pub mod state;
 pub mod storage;
+pub mod telemetry;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,15 @@
 use media_management_service::auth::AuthMode;
-use media_management_service::config::{Config, RunMode};
+use media_management_service::config::Config;
 use media_management_service::db;
 use media_management_service::routes;
 use media_management_service::state::AppState;
 use media_management_service::storage::Storage;
-use tracing_subscriber::EnvFilter;
-
-fn init_tracing(config: &Config) {
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| "media_management_service=info,tower_http=info".into());
-
-    if config.run_mode == RunMode::Production {
-        tracing_subscriber::fmt()
-            .json()
-            .with_env_filter(filter)
-            .init();
-    } else {
-        tracing_subscriber::fmt()
-            .pretty()
-            .with_env_filter(filter)
-            .init();
-    }
-}
+use media_management_service::telemetry;
 
 #[tokio::main]
 async fn main() {
     let config = Config::from_env();
-    init_tracing(&config);
+    let otel_guard = telemetry::init(&config);
 
     let db_pool = db::connect(&config)
         .await
@@ -60,6 +43,9 @@ async fn main() {
         .with_graceful_shutdown(shutdown_signal())
         .await
         .expect("server error");
+
+    tracing::info!("shutting down telemetry");
+    otel_guard.shutdown();
 }
 
 async fn shutdown_signal() {

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
 use axum::http::header::{self, HeaderName};
-use axum::http::{HeaderValue, Request, StatusCode};
+use axum::http::{HeaderMap, HeaderValue, Request, StatusCode};
+use opentelemetry::global;
+use opentelemetry::propagation::{Extractor, Injector};
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{AllowHeaders, AllowMethods, AllowOrigin, CorsLayer};
 use tower_http::request_id::{
@@ -131,6 +133,95 @@ pub fn referrer_policy_layer() -> SetResponseHeaderLayer<HeaderValue> {
         HeaderName::from_static("referrer-policy"),
         HeaderValue::from_static("strict-origin-when-cross-origin"),
     )
+}
+
+// -- Trace context propagation -----------------------------------------------
+
+/// Tower layer that extracts W3C traceparent/tracestate from request headers
+/// and injects trace context into response headers for distributed tracing.
+#[derive(Clone)]
+pub struct TraceContextLayer;
+
+impl<S> tower::Layer<S> for TraceContextLayer {
+    type Service = TraceContextService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TraceContextService { inner }
+    }
+}
+
+/// Tower service that propagates W3C trace context headers.
+#[derive(Clone)]
+pub struct TraceContextService<S> {
+    inner: S,
+}
+
+impl<S, B> tower::Service<Request<B>> for TraceContextService<S>
+where
+    S: tower::Service<Request<B>, Response = axum::response::Response> + Clone + Send + 'static,
+    S::Future: Send,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<B>) -> Self::Future {
+        let parent_cx = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&HeaderExtractor(request.headers()))
+        });
+
+        let _guard = parent_cx.clone().attach();
+
+        let future = self.inner.call(request);
+
+        Box::pin(async move {
+            let mut response = future.await?;
+
+            global::get_text_map_propagator(|propagator| {
+                propagator.inject_context(&parent_cx, &mut HeaderInjector(response.headers_mut()));
+            });
+
+            Ok(response)
+        })
+    }
+}
+
+pub fn trace_context_layer() -> TraceContextLayer {
+    TraceContextLayer
+}
+
+struct HeaderExtractor<'a>(&'a HeaderMap);
+
+impl Extractor for HeaderExtractor<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0.keys().map(HeaderName::as_str).collect()
+    }
+}
+
+struct HeaderInjector<'a>(&'a mut HeaderMap);
+
+impl Injector for HeaderInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(name) = HeaderName::from_bytes(key.as_bytes()) {
+            if let Ok(val) = HeaderValue::from_str(&value) {
+                self.0.insert(name, val);
+            }
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -81,6 +81,7 @@ pub fn router(state: AppState) -> Router {
         .layer(GovernorLayer::new(governor_config))
         .layer(cors)
         .layer(middleware::propagate_request_id_layer())
+        .layer(middleware::trace_context_layer())
         .layer(middleware::trace_layer())
         .layer(middleware::request_id_layer())
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,120 @@
+//! Observability initialization: structured logging + optional OpenTelemetry.
+//!
+//! When `OTEL_EXPORTER_OTLP_ENDPOINT` is configured, traces and metrics are
+//! exported via OTLP/HTTP. When empty or unset, only structured logging is
+//! active (no-op, no errors, no overhead).
+
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry::{KeyValue, global};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::propagation::TraceContextPropagator;
+use opentelemetry_sdk::trace::SdkTracerProvider;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, Layer};
+
+use crate::config::{Config, RunMode};
+
+const SERVICE_NAME: &str = "media-management-service";
+
+/// Guard that must be held for the lifetime of the application.
+/// On drop or explicit shutdown, flushes pending telemetry and shuts down
+/// OTEL providers.
+pub struct OtelGuard {
+    tracer_provider: Option<SdkTracerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+}
+
+impl OtelGuard {
+    /// Flush pending telemetry and shut down providers.
+    /// Call this after the server stops accepting requests.
+    pub fn shutdown(&self) {
+        if let Some(tp) = &self.tracer_provider {
+            if let Err(e) = tp.shutdown() {
+                eprintln!("failed to shutdown tracer provider: {e}");
+            }
+        }
+        if let Some(mp) = &self.meter_provider {
+            if let Err(e) = mp.shutdown() {
+                eprintln!("failed to shutdown meter provider: {e}");
+            }
+        }
+    }
+}
+
+/// Initialize observability: tracing subscriber + optional OTEL export.
+///
+/// When `config.otel_endpoint` is `Some`, traces and metrics are exported
+/// via OTLP/HTTP to the configured collector. When `None`, only structured
+/// logging is active.
+pub fn init(config: &Config) -> OtelGuard {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| "media_management_service=info,tower_http=info".into());
+
+    let fmt_layer = if config.run_mode == RunMode::Production {
+        tracing_subscriber::fmt::layer().json().boxed()
+    } else {
+        tracing_subscriber::fmt::layer().pretty().boxed()
+    };
+
+    let (otel_layer, tracer_provider, meter_provider) =
+        if let Some(ref endpoint) = config.otel_endpoint {
+            let resource = Resource::builder_empty()
+                .with_attributes([
+                    KeyValue::new("service.name", SERVICE_NAME),
+                    KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+                ])
+                .build();
+
+            // Traces
+            let span_exporter = opentelemetry_otlp::SpanExporter::builder()
+                .with_http()
+                .with_endpoint(format!("{endpoint}/v1/traces"))
+                .build()
+                .expect("failed to build OTLP span exporter");
+
+            let tp = SdkTracerProvider::builder()
+                .with_batch_exporter(span_exporter)
+                .with_resource(resource.clone())
+                .build();
+
+            global::set_tracer_provider(tp.clone());
+            global::set_text_map_propagator(TraceContextPropagator::new());
+
+            let tracer = tp.tracer(SERVICE_NAME);
+            let otel_layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+            // Metrics
+            let metric_exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_http()
+                .with_endpoint(format!("{endpoint}/v1/metrics"))
+                .build()
+                .expect("failed to build OTLP metric exporter");
+
+            let mp = SdkMeterProvider::builder()
+                .with_periodic_exporter(metric_exporter)
+                .with_resource(resource)
+                .build();
+
+            global::set_meter_provider(mp.clone());
+
+            tracing::info!("OpenTelemetry enabled, exporting to {endpoint}");
+
+            (Some(otel_layer), Some(tp), Some(mp))
+        } else {
+            (None, None, None)
+        };
+
+    tracing_subscriber::registry()
+        .with(filter)
+        .with(fmt_layer)
+        .with(otel_layer)
+        .init();
+
+    OtelGuard {
+        tracer_provider,
+        meter_provider,
+    }
+}


### PR DESCRIPTION
## Summary
- Add distributed tracing and metrics export via OpenTelemetry OTLP/HTTP
- Graceful degradation when `OTEL_EXPORTER_OTLP_ENDPOINT` is unset (no-op, no errors)
- W3C trace context propagation (traceparent/tracestate headers)
- All 11 HTTP handlers instrumented with relevant span attributes (media_id, user_id, operation)

## Task
Closes beads task `media-mgmt-svc-9qa`: Phase 7: OpenTelemetry integration

## Changes
- `src/telemetry.rs` — New module: OTEL initialization with OtelGuard for explicit shutdown, configures SdkTracerProvider + SdkMeterProvider with batch/periodic exporters
- `src/main.rs` — Replace `init_tracing()` with `telemetry::init()`, add OTEL shutdown after graceful server stop
- `src/middleware.rs` — Add `TraceContextLayer`/`TraceContextService` Tower middleware for W3C trace context propagation
- `src/routes.rs` — Wire `trace_context_layer()` into the middleware stack
- `src/handlers.rs` — Add `#[tracing::instrument]` with `skip_all` and relevant fields to all handlers
- `src/lib.rs` — Add `pub mod telemetry;`

## Validation
- [x] All 93 tests pass
- [x] Clippy clean (deny all + pedantic)
- [x] Format clean
- [x] cargo-deny clean
- [x] cargo-audit clean
- [x] Gitleaks clean

Generated with [Claude Code](https://claude.com/claude-code)