### PR TITLE
media-mgmt-svc-q2q: add devcontainer and Renovate configs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "Media Management Service",
+  "image": "mcr.microsoft.com/devcontainers/rust:1-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers-contrib/features/go-task:1": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml",
+        "serayuzgur.crates",
+        "vadimcn.vscode-lldb"
+      ],
+      "settings": {
+        "rust-analyzer.check.command": "clippy",
+        "rust-analyzer.check.extraArgs": ["--all-targets"],
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "postCreateCommand": "task setup",
+  "forwardPorts": [3000],
+  "remoteUser": "vscode"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "group:allNonMajor",
+    ":separateMajorReleases"
+  ],
+  "cargo": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "labels": ["dependencies"],
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "matchManagers": ["cargo"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "groupName": "Rust minor/patch updates",
+      "automerge": true
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions updates",
+      "automerge": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.devcontainer/devcontainer.json` with Rust image, go-task, VS Code extensions, and formatOnSave
- Add `renovate.json` with cargo enabled, weekly lock file maintenance, and auto-merge for minor/patch deps

## Task
Closes beads task `media-mgmt-svc-q2q`: Phase 8b: Devcontainer and Renovate

## Changes
| File | Description |
|------|-------------|
| `.devcontainer/devcontainer.json` | Standardized dev environment for VS Code / Codespaces |
| `renovate.json` | Automated dependency updates with safe auto-merge rules |

## Validation
- [x] JSON syntax validated
- [x] All 93 tests pass
- [x] All lint/format hooks pass
- [x] Gitleaks security scan clean

Generated with [Claude Code](https://claude.com/claude-code)