### PR TITLE
media-mgmt-svc-95j: Add multi-stage Dockerfile with cargo-chef

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+target/
+.git/
+.cargo/
+.env
+.env.*
+docs/
+k8s/
+.beads/
+.serena/
+.devcontainer/
+media/
+*.md
+lefthook.yml
+Taskfile.yml
+renovate.json

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,2 @@
+ignored:
+  - DL3008 # Don't pin apt package versions — fragile on Debian, breaks when versions rotate

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# Rust version must match or exceed what generated Cargo.lock (currently 1.93)
+ARG RUST_VERSION=1.93
+
+# Stage 1: Compute dependency recipe
+FROM rust:${RUST_VERSION}-bookworm AS chef
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
+    && cargo binstall cargo-chef --no-confirm
+WORKDIR /app
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 2: Build dependencies only (this layer is cached)
+FROM rust:${RUST_VERSION}-bookworm AS cook
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update && apt-get install -y --no-install-recommends cmake && rm -rf /var/lib/apt/lists/*
+RUN curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash \
+    && cargo binstall cargo-chef --no-confirm
+WORKDIR /app
+COPY --from=chef /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+
+# Stage 3: Build application (only this rebuilds on code changes)
+FROM cook AS builder
+COPY . .
+RUN cargo build --release
+
+# Stage 4: Minimal runtime
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN useradd -r -s /bin/false media
+COPY --from=builder /app/target/release/media-management-service /usr/local/bin/
+USER media
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD curl -f http://localhost:3000/api/v1/media-management/health || exit 1
+CMD ["media-management-service"]


### PR DESCRIPTION
## Summary
- Multi-stage Dockerfile using cargo-chef for optimized layer caching
- Code-only changes rebuild only Stage 3 (~41s vs ~110s full dep rebuild)
- .dockerignore excludes target/, .cargo/ (mold linker), and dev files from build context

## Task
Closes beads task `media-mgmt-svc-95j`: Phase 9a: Dockerfile with cargo-chef

## Changes
- `Dockerfile` — 4-stage build: chef (recipe) → cook (deps) → builder (app) → runtime (bookworm-slim)
- `.dockerignore` — Excludes target/, .git/, .cargo/, docs/, k8s/, .env*, media/
- `.hadolint.yaml` — Ignores DL3008 (apt version pinning is fragile on Debian)

## Design deviations
- **Rust 1.93** instead of 1.85: Cargo.lock pins deps (time, cargo-platform) requiring 1.88+; 1.93 matches local dev toolchain
- **cargo-binstall** for cargo-chef: Avoids compiling cargo-chef from source (its deps also need 1.88+)
- **cmake** added to cook stage: aws-lc-rs (transitive via jsonwebtoken) requires cmake for C compilation

## Validation
- [x] All 93 unit tests pass
- [x] Lint clean (hadolint, cargo-deny, gitleaks)
- [x] Docker build succeeds (image: 101MB)
- [x] Runtime user is `media` (non-root)
- [x] Port 3000 exposed with healthcheck configured

Generated with [Claude Code](https://claude.com/claude-code)